### PR TITLE
flags extra space as a misalignment, removes on fix

### DIFF
--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -146,7 +146,7 @@ module.exports = {
                 // get the prevTokenEnd and fromTokenStart of all lines
                 var lines = surroundingImports.map(getLineInfo);
 
-                // getting greatest endpoint of previous tokens
+                // use greatest endpoint of previous tokens as alignment column
                 var alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
 
                 // add 1 for the space

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -118,6 +118,18 @@ module.exports = {
 
         }
 
+        function getLineInfo(node) {
+            var sourceCode = context.getSourceCode();
+            const fromToken = getFromKeyword(node);
+            const fromTokenStart = fromToken.loc.start.column;
+            const prevToken = sourceCode.getTokenBefore(fromToken);
+            const prevTokenEnd = prevToken.loc.end.column;
+            return {
+                prevTokenEnd: prevTokenEnd,
+                fromTokenStart: fromTokenStart,
+            }
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -131,16 +143,21 @@ module.exports = {
 
                 var surroundingImports = findSurroundingImports(node);
 
-                var fromKeywords = surroundingImports.map(function (node) { return getFromKeyword(node); });
-                var fromColumns = fromKeywords.map(function (token) { return token.loc.start.column; });
+                // get the prevTokenEnd and fromTokenStart of all lines
+                var lines = surroundingImports.map(getLineInfo);
 
-                var getMaxColumn = fromColumns.reduce(function (max, column) { return Math.max(max, column); }, 0);
+                // getting greatest endpoint of previous tokens
+                var alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
 
-                var nodeFromKeyword = getFromKeyword(node);
-                var nodeFromColumn = nodeFromKeyword.loc.start.column;
+                // add 1 for the space
+                alignmentColumn += 1;
 
-                if (nodeFromColumn !== getMaxColumn) {
-                    reportUnalignedImportStatement(node, getMaxColumn - nodeFromColumn);
+                // get current line info
+                var line = getLineInfo(node)
+
+                // check alignment of current line
+                if (line.fromTokenStart !== alignmentColumn) {
+                    reportUnalignedImportStatement(node, alignmentColumn - line.fromTokenStart);
                 }
 
             }

--- a/tests/lib/rules/import-align.js
+++ b/tests/lib/rules/import-align.js
@@ -25,21 +25,71 @@ ruleTester.run("import-align", rule, {
 
     valid: [
 
-        { code: "import foo from 'foo';\nimport bar from 'bar';\n", parserOptions: { sourceType: "module" } },
-        { code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\n", parserOptions: { sourceType: "module" } },
-        { code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\nimport {\n    A,\n    B\n} from 'foo';\n", parserOptions: { sourceType: "module" } }
+        {
+            code: "import foo from 'foo';\nimport bar from 'bar';\n",
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\n",
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\nimport {\n    A,\n    B\n} from 'foo';\n",
+            parserOptions: { sourceType: "module" }
+        }
 
     ],
 
     invalid: [
 
-        { code: "import foo from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';", parserOptions: { sourceType: "module" },
-          output: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
-          errors: [{ message: "Unaligned import statement" }] },
+        {
+            code: "import foo from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            parserOptions: { sourceType: "module" },
+            output: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            errors: [{ message: "Unaligned import statement" }]
+        },
 
-        { code: "import foo from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';", parserOptions: { sourceType: "module" },
-          output: "import foo                                from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
-          errors: [{ message: "Unaligned import statement" }] }
+        {
+            code: "import foo from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            parserOptions: { sourceType: "module" },
+            output: "import foo                                from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            errors: [{ message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo   from 'foo';\nimport bar   from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo    from 'foo';\nimport bar   from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo    from 'foo';\nimport bar from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import { foo }    from 'foo';\nimport bar       from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import { foo }    from 'foo';\nimport bar     from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }]
+        },
 
     ]
 


### PR DESCRIPTION
Fixes https://github.com/arcanis/eslint-plugin-arca/issues/1

![Screen Recording 2019-03-23 at 12 23 12am mov](https://user-images.githubusercontent.com/1355312/54861610-6cac1100-4d02-11e9-9937-6adc7efb1915.gif)

(Obviously fix-on-save makes this easier than what I'm demoing above, but I wanted to test that each error is separately addressable.)

This is super handy. But it's going to throw a lot of lint errors in files that previously passed. For example, in one of my projects:

```
✖ 366 problems (365 errors, 1 warning)
  365 errors and 0 warnings potentially fixable with the `--fix` option.
```

So I guess you could release this as a major version bump, or maybe it should require an opt-in settings flag in the lint config?

(I have another idea to have a settings flag for minColumnWidth, so I might explore that in another branch.)
