### PR TITLE
adds options for collapseExtraSpace and minColumnWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ To use these options:
 {
     "rules": {
         "arca/import-align": [2, {
-            collapseExtraSpace: true,
-            minColumnWidth: 20
+            "collapseExtraSpace": true,
+            "minColumnWidth": 20
         }]
     }
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ Then configure the rules you want to use under the rules section.
 * [`arca/newline-after-import-section`](https://github.com/arcanis/eslint-plugin-arca/blob/master/docs/rules/newline-after-var.md) - require an empty newline after an import section
 * [`arca/no-default-export`](https://github.com/arcanis/eslint-plugin-arca/blob/master/docs/rules/no-default-export.md) - disallow default exports
 
+## Options for import-align rule
+
+The import-align rule has support for some additional options:
+
+- `collapseExtraSpace` (Boolean, default: false) - If true, removes any unneeded extra space, collapsing lines to the minimum needed. Useful for correcting alignment after removing a long import.
+- `minColumnWidth` (Number, default: 0) - Ensures that the right half of each import doesn't start before the desired minimum column width. If the longest import exceeds this value, the minimum column width will be ignored and the longer value will be used for alignment.
+
+To use these options:
+
+```json
+{
+    "rules": {
+        "arca/import-align": [2, {
+            collapseExtraSpace: true,
+            minColumnWidth: 20
+        }]
+    }
+}
+```
+
 ## License
 
 > **Copyright © 2016 Maël Nison**

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -146,7 +146,7 @@ module.exports = {
                 // get the prevTokenEnd and fromTokenStart of all lines
                 var lines = surroundingImports.map(getLineInfo);
 
-                // getting greatest endpoint of previous tokens
+                // use greatest endpoint of previous tokens as alignment column
                 var alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
 
                 // add 1 for the space

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -118,6 +118,18 @@ module.exports = {
 
         }
 
+        function getLineInfo(node) {
+            var sourceCode = context.getSourceCode();
+            const fromToken = getFromKeyword(node);
+            const fromTokenStart = fromToken.loc.start.column;
+            const prevToken = sourceCode.getTokenBefore(fromToken);
+            const prevTokenEnd = prevToken.loc.end.column;
+            return {
+                prevTokenEnd: prevTokenEnd,
+                fromTokenStart: fromTokenStart,
+            }
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -131,16 +143,21 @@ module.exports = {
 
                 var surroundingImports = findSurroundingImports(node);
 
-                var fromKeywords = surroundingImports.map(function (node) { return getFromKeyword(node); });
-                var fromColumns = fromKeywords.map(function (token) { return token.loc.start.column; });
+                // get the prevTokenEnd and fromTokenStart of all lines
+                var lines = surroundingImports.map(getLineInfo);
 
-                var getMaxColumn = fromColumns.reduce(function (max, column) { return Math.max(max, column); }, 0);
+                // getting greatest endpoint of previous tokens
+                var alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
 
-                var nodeFromKeyword = getFromKeyword(node);
-                var nodeFromColumn = nodeFromKeyword.loc.start.column;
+                // add 1 for the space
+                alignmentColumn += 1;
 
-                if (nodeFromColumn !== getMaxColumn) {
-                    reportUnalignedImportStatement(node, getMaxColumn - nodeFromColumn);
+                // get current line info
+                var line = getLineInfo(node)
+
+                // check alignment of current line
+                if (line.fromTokenStart !== alignmentColumn) {
+                    reportUnalignedImportStatement(node, alignmentColumn - line.fromTokenStart);
                 }
 
             }

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -41,11 +41,11 @@ module.exports = {
         //--------------------------------------------------------------------------
         // Read options, merge with defaults
         //--------------------------------------------------------------------------
-        const defaultOptions = {
+        var defaultOptions = {
             collapseExtraSpace: false,
             minColumnWidth: 0,
         }
-        const options = Object.assign(defaultOptions, context.options[1]);
+        var options = Object.assign({}, defaultOptions, context.options[1]);
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -144,10 +144,10 @@ module.exports = {
 
         function getLineInfo(node) {
             var sourceCode = context.getSourceCode();
-            const fromToken = getFromKeyword(node);
-            const fromTokenStart = fromToken.loc.start.column;
-            const prevToken = sourceCode.getTokenBefore(fromToken);
-            const prevTokenEnd = prevToken.loc.end.column;
+            var fromToken = getFromKeyword(node);
+            var fromTokenStart = fromToken.loc.start.column;
+            var prevToken = sourceCode.getTokenBefore(fromToken);
+            var prevTokenEnd = prevToken.loc.end.column;
             return {
                 prevTokenEnd: prevTokenEnd,
                 fromTokenStart: fromTokenStart,

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -130,6 +130,31 @@ module.exports = {
             }
         }
 
+        function getAlignmentColumn(lines) {
+            var alignmentColumn;
+
+            if (context.settings.collapseExtraSpace) {
+
+                // use greatest endpoint of previous tokens as alignment column
+                alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
+
+                // add 1 for the space
+                alignmentColumn += 1;
+
+            } else {
+
+                // use greatest start of from tokens as alignment column
+                alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.fromTokenStart); }, 0)
+
+            }
+
+            // check if alignment column is lower than minColumnWidth, if defined
+            if (context.settings.minColumnWidth)
+                alignmentColumn = Math.max(alignmentColumn, context.settings.minColumnWidth);
+
+            return alignmentColumn;
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -146,11 +171,7 @@ module.exports = {
                 // get the prevTokenEnd and fromTokenStart of all lines
                 var lines = surroundingImports.map(getLineInfo);
 
-                // use greatest endpoint of previous tokens as alignment column
-                var alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
-
-                // add 1 for the space
-                alignmentColumn += 1;
+                var alignmentColumn = getAlignmentColumn(lines);
 
                 // get current line info
                 var line = getLineInfo(node)

--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -17,11 +17,35 @@ module.exports = {
         fixable: `whitespace`,
 
         schema: [
+            {
+                "enum": [0, 1, 2]
+            },
+            {
+                type: 'object',
+                properties: {
+                    collapseExtraSpace: {
+                        type: 'boolean',
+                    },
+                    minColumnWidth: {
+                        type: 'number',
+                    },
+                },
+                additionalProperties: false,
+            }
         ]
 
     },
 
     create: function(context) {
+
+        //--------------------------------------------------------------------------
+        // Read options, merge with defaults
+        //--------------------------------------------------------------------------
+        const defaultOptions = {
+            collapseExtraSpace: false,
+            minColumnWidth: 0,
+        }
+        const options = Object.assign(defaultOptions, context.options[1]);
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -133,7 +157,7 @@ module.exports = {
         function getAlignmentColumn(lines) {
             var alignmentColumn;
 
-            if (context.settings.collapseExtraSpace) {
+            if (options.collapseExtraSpace) {
 
                 // use greatest endpoint of previous tokens as alignment column
                 alignmentColumn = lines.reduce(function (max, line) { return Math.max(max, line.prevTokenEnd); }, 0)
@@ -149,8 +173,8 @@ module.exports = {
             }
 
             // check if alignment column is lower than minColumnWidth, if defined
-            if (context.settings.minColumnWidth)
-                alignmentColumn = Math.max(alignmentColumn, context.settings.minColumnWidth);
+            if (options.minColumnWidth)
+                alignmentColumn = Math.max(alignmentColumn, options.minColumnWidth);
 
             return alignmentColumn;
         }

--- a/tests/lib/rules/import-align.js
+++ b/tests/lib/rules/import-align.js
@@ -25,21 +25,71 @@ ruleTester.run("import-align", rule, {
 
     valid: [
 
-        { code: "import foo from 'foo';\nimport bar from 'bar';\n", parserOptions: { sourceType: "module" } },
-        { code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\n", parserOptions: { sourceType: "module" } },
-        { code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\nimport {\n    A,\n    B\n} from 'foo';\n", parserOptions: { sourceType: "module" } }
+        {
+            code: "import foo from 'foo';\nimport bar from 'bar';\n",
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\n",
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\nimport {\n    A,\n    B\n} from 'foo';\n",
+            parserOptions: { sourceType: "module" }
+        }
 
     ],
 
     invalid: [
 
-        { code: "import foo from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';", parserOptions: { sourceType: "module" },
-          output: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
-          errors: [{ message: "Unaligned import statement" }] },
+        {
+            code: "import foo from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            parserOptions: { sourceType: "module" },
+            output: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            errors: [{ message: "Unaligned import statement" }]
+        },
 
-        { code: "import foo from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';", parserOptions: { sourceType: "module" },
-          output: "import foo                                from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
-          errors: [{ message: "Unaligned import statement" }] }
+        {
+            code: "import foo from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            parserOptions: { sourceType: "module" },
+            output: "import foo                                from 'foo';\n\nimport bar                                from 'bar';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';",
+            errors: [{ message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo   from 'foo';\nimport bar   from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo    from 'foo';\nimport bar   from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo    from 'foo';\nimport bar from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import { foo }    from 'foo';\nimport bar       from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import { foo }    from 'foo';\nimport bar     from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            errors: [{ message: "Unaligned import statement" }]
+        },
 
     ]
 

--- a/tests/lib/rules/import-align.js
+++ b/tests/lib/rules/import-align.js
@@ -36,6 +36,21 @@ ruleTester.run("import-align", rule, {
         {
             code: "import foo                                from 'foo';\nimport supercalifragilisticexpialidocious from 'supercalifragilisticexpialidocious';\nimport {\n    A,\n    B\n} from 'foo';\n",
             parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import foo          from 'foo';\nimport bar          from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            settings: { minColumnWidth: 20 }
+        },
+        {
+            code: "import supercalifragilisticexpialidocious from 'foo';\nimport bar                                from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            settings: { minColumnWidth: 20 }
+        },
+        {
+            code: "import foo    from 'foo';\nimport bar    from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            settings: { collapseExtraSpace: false }
         }
 
     ],
@@ -60,6 +75,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo   from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            settings: { collapseExtraSpace: true },
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -67,6 +83,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            settings: { collapseExtraSpace: true },
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -74,6 +91,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
+            settings: { collapseExtraSpace: true },
             errors: [{ message: "Unaligned import statement" }]
         },
 
@@ -81,6 +99,7 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar       from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            settings: { collapseExtraSpace: true },
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -88,8 +107,25 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar     from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
+            settings: { collapseExtraSpace: true },
             errors: [{ message: "Unaligned import statement" }]
         },
+
+        {
+            code: "import foo       from 'foo';\nimport bar       from 'bar';\n",
+            output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            settings: { minColumnWidth: 20 },
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        },
+
+        {
+            code: "import foo              from 'foo';\nimport bar              from 'bar';\n",
+            output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
+            parserOptions: { sourceType: "module" },
+            settings: { minColumnWidth: 20, collapseExtraSpace: true },
+            errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
+        }
 
     ]
 

--- a/tests/lib/rules/import-align.js
+++ b/tests/lib/rules/import-align.js
@@ -40,17 +40,17 @@ ruleTester.run("import-align", rule, {
         {
             code: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            settings: { minColumnWidth: 20 }
+            options: [2, { minColumnWidth: 20 }]
         },
         {
             code: "import supercalifragilisticexpialidocious from 'foo';\nimport bar                                from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            settings: { minColumnWidth: 20 }
+            options: [2, { minColumnWidth: 20 }]
         },
         {
             code: "import foo    from 'foo';\nimport bar    from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            settings: { collapseExtraSpace: false }
+            options: [2, { collapseExtraSpace: false }]
         }
 
     ],
@@ -75,7 +75,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo   from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            settings: { collapseExtraSpace: true },
+            options: [2, { collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -83,7 +83,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            settings: { collapseExtraSpace: true },
+            options: [2, { collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -91,7 +91,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            settings: { collapseExtraSpace: true },
+            options: [2, { collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }]
         },
 
@@ -99,7 +99,7 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar       from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
-            settings: { collapseExtraSpace: true },
+            options: [2, { collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -107,7 +107,7 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar     from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
-            settings: { collapseExtraSpace: true },
+            options: [2, { collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }]
         },
 
@@ -115,7 +115,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo       from 'foo';\nimport bar       from 'bar';\n",
             output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            settings: { minColumnWidth: 20 },
+            options: [2, { minColumnWidth: 20 }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -123,7 +123,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo              from 'foo';\nimport bar              from 'bar';\n",
             output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            settings: { minColumnWidth: 20, collapseExtraSpace: true },
+            options: [2, { minColumnWidth: 20, collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         }
 


### PR DESCRIPTION
Fixes https://github.com/arcanis/eslint-plugin-arca/issues/1

From the ReadMe in this PR:

---

## Options for import-align rule

The import-align rule has support for some additional options:

- `collapseExtraSpace` (Boolean, default: false) - If true, removes any unneeded extra space, collapsing lines to the minimum needed. Useful for correcting alignment after removing a long import.
- `minColumnWidth` (Number, default: 0) - Ensures that the right half of each import doesn't start before the desired minimum column width. If the longest import exceeds this value, the minimum column width will be ignored and the longer value will be used for alignment.

To use these options:

```json
{
    "rules": {
        "arca/import-align": [2, {
            "collapseExtraSpace": true,
            "minColumnWidth": 20
        }]
    }
}
```

---

In action:
![Screen Recording 2019-03-23 at 12 23 12am mov](https://user-images.githubusercontent.com/1355312/54861610-6cac1100-4d02-11e9-9937-6adc7efb1915.gif)

(Obviously fix-on-save makes this easier than what I'm demoing above, but I wanted to test that each error is separately addressable.)

This is super handy. But it would throw a lot of lint errors in files that previously passed. For example, in a larger project I work on:

```
✖ 365 problems (365 errors)
  365 errors potentially fixable with the `--fix` option.
```

So that's why I decided to make this behavior opt-in via eslint config.

(This PR is branched from my previous PR https://github.com/arcanis/eslint-plugin-arca/pull/4 and supercedes it, so if you like the idea of hiding these breaking changes behind opt-in flags, you can ignore that PR and just look at this one.)