### PR TITLE
fixes options schema

### DIFF
--- a/lib/rules/import-align.js
+++ b/lib/rules/import-align.js
@@ -18,9 +18,6 @@ module.exports = {
 
         schema: [
             {
-                "enum": [0, 1, 2]
-            },
-            {
                 type: 'object',
                 properties: {
                     collapseExtraSpace: {
@@ -45,7 +42,7 @@ module.exports = {
             collapseExtraSpace: false,
             minColumnWidth: 0,
         }
-        var options = Object.assign({}, defaultOptions, context.options[1]);
+        var options = Object.assign({}, defaultOptions, context.options[0]);
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/tests/lib/rules/import-align.js
+++ b/tests/lib/rules/import-align.js
@@ -40,17 +40,17 @@ ruleTester.run("import-align", rule, {
         {
             code: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            options: [2, { minColumnWidth: 20 }]
+            options: [{ minColumnWidth: 20 }]
         },
         {
             code: "import supercalifragilisticexpialidocious from 'foo';\nimport bar                                from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            options: [2, { minColumnWidth: 20 }]
+            options: [{ minColumnWidth: 20 }]
         },
         {
             code: "import foo    from 'foo';\nimport bar    from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            options: [2, { collapseExtraSpace: false }]
+            options: [{ collapseExtraSpace: false }]
         }
 
     ],
@@ -75,7 +75,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo   from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            options: [2, { collapseExtraSpace: true }],
+            options: [{ collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -83,7 +83,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar   from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            options: [2, { collapseExtraSpace: true }],
+            options: [{ collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -91,7 +91,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo    from 'foo';\nimport bar from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import foo from 'foo';\nimport bar from 'bar';\n",
-            options: [2, { collapseExtraSpace: true }],
+            options: [{ collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }]
         },
 
@@ -99,7 +99,7 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar       from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
-            options: [2, { collapseExtraSpace: true }],
+            options: [{ collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -107,7 +107,7 @@ ruleTester.run("import-align", rule, {
             code: "import { foo }    from 'foo';\nimport bar     from 'bar';\n",
             parserOptions: { sourceType: "module" },
             output: "import { foo } from 'foo';\nimport bar     from 'bar';\n",
-            options: [2, { collapseExtraSpace: true }],
+            options: [{ collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }]
         },
 
@@ -115,7 +115,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo       from 'foo';\nimport bar       from 'bar';\n",
             output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            options: [2, { minColumnWidth: 20 }],
+            options: [{ minColumnWidth: 20 }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         },
 
@@ -123,7 +123,7 @@ ruleTester.run("import-align", rule, {
             code: "import foo              from 'foo';\nimport bar              from 'bar';\n",
             output: "import foo          from 'foo';\nimport bar          from 'bar';\n",
             parserOptions: { sourceType: "module" },
-            options: [2, { minColumnWidth: 20, collapseExtraSpace: true }],
+            options: [{ minColumnWidth: 20, collapseExtraSpace: true }],
             errors: [{ message: "Unaligned import statement" }, { message: "Unaligned import statement" }]
         }
 


### PR DESCRIPTION
Fixes https://github.com/arcanis/eslint-plugin-arca/issues/6

I was getting Eslint errors when trying to apply the new options in project using 0.7.0. Turns out that eslint plugins don't receive the first option (the error level), just the options following it. So I've updated the schema to describe just the options object, and changed the code to access the option correctly.
