### PR TITLE
[import-ordering] use stable sort

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "eslint.autoFixOnSave": true,
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
-    }
+    },
+    "editor.formatOnSave": false
 }

--- a/lib/rules/import-ordering.js
+++ b/lib/rules/import-ordering.js
@@ -34,7 +34,7 @@ module.exports = {
             }
 
         }
- 
+
       }]
 
     },
@@ -132,7 +132,11 @@ module.exports = {
 
             var fixedImports = importDeclarations.slice().sort(function (a, b) {
 
-                return compareModules(a, b) === null ? -1 : 1
+                var compared = compareModules(a, b);
+                if (compared[0] === null)
+                    return 0
+
+                return compared[0];
 
             }).reduce(function (sourceText, declaration, index) {
 
@@ -188,23 +192,23 @@ module.exports = {
         function compareModules(a, b) {
 
             if (a.type !== "ImportDeclaration" || b.type !== "ImportDeclaration")
-                return null;
+                return [null];
 
             if (a.specifiers.length && !b.specifiers.length)
-                return "side-effects go first";
+                return [1, "side-effects go first"];
 
             if (!a.specifiers.length && b.specifiers.length)
-                return null;
+                return [-1, "side-effects go first"]
 
             var aMultiline = a.loc.start.line !== a.loc.end.line;
             var bMultiline = b.loc.start.line !== b.loc.end.line;
 
             if (options.hoistOneliners) {
                 if (aMultiline && !bMultiline)
-                    return "multiline imports are last";
+                    return [1, "multiline imports are last"];
 
                 if (!aMultiline && bMultiline) {
-                    return null;
+                    return [-1, "multiline imports are last"];
                 }
             }
 
@@ -212,38 +216,45 @@ module.exports = {
             var bSource = b.source.value;
 
             if (aSource === bSource)
-                return null;
+                return [null];
 
             var aLevel = getModuleLevel(aSource);
             var bLevel = getModuleLevel(bSource);
 
             if (aLevel < bLevel) {
 
-                return null;
+                if (aLevel === 0) {
+                    return [-1, "vendors go first"];
+                } else {
+                    return [-1, "'" + sectionsPatterns[aLevel - 1] + "' goes before '" + sectionsPatterns[bLevel - 1] + "'"];
+                }
 
             } else if (aLevel > bLevel) {
 
                 if (bLevel === 0) {
-                    return "vendors go first";
+                    return [1, "vendors go first"];
                 } else {
-                    return "'" + sectionsPatterns[bLevel - 1] + "' goes before '" + sectionsPatterns[aLevel - 1] + "'";
+                    return [1, "'" + sectionsPatterns[bLevel - 1] + "' goes before '" + sectionsPatterns[aLevel - 1] + "'"];
                 }
 
             } else {
 
                 if (bSource.substr(0, aSource.length + 1) === aSource + "/")
-                    return "subdirectories go before their indexes";
+                    return [1, "subdirectories go before their indexes"];
+
+                if (aSource.substr(0, bSource.length + 1) === bSource + "/")
+                    return [-1, "subdirectories go before their indexes"];
 
                 if (bSource.substr(0, aSource.length) === aSource)
-                    return "lexicographic order";
+                    return [1,"lexicographic order"];
 
                 if (aSource.substr(0, bSource.length) === bSource)
-                    return null;
+                    return [-1,"lexicographic order"];
 
                 if (aSource > bSource) {
-                    return "lexicographic order";
+                    return [1, "lexicographic order"];
                 } else {
-                    return null;
+                    return [-1, "lexicographic order"];
                 }
 
             }
@@ -269,9 +280,9 @@ module.exports = {
 
             iterate();
 
-            for (var errorReason; iteratorNode && (errorReason = compareModules(iteratorNode, node)) !== null; iterate()) {
+            for (var errorReason; iteratorNode && (errorReason = compareModules(iteratorNode, node))[0] === 1; iterate()) {
                 firstErroneousNode = iteratorNode;
-                firstErrorReason = errorReason;
+                firstErrorReason = errorReason[1];
             }
 
             if (firstErroneousNode) {

--- a/lib/rules/import-ordering.js
+++ b/lib/rules/import-ordering.js
@@ -134,7 +134,7 @@ module.exports = {
 
                 var compared = compareModules(a, b);
                 if (compared[0] === null)
-                    return 0
+                    return 0;
 
                 return compared[0];
 

--- a/tests/lib/rules/import-ordering.js
+++ b/tests/lib/rules/import-ordering.js
@@ -29,6 +29,11 @@ ruleTester.run("import-ordering", rule, {
         {
             code: "import 'foo';\nimport bar1 from 'bar/bar';\nimport bar2 from 'bar';\nimport foo1 from 'foo/foo';\nimport foo2 from 'foo';\n\nimport bar3 from 'common/bar';\nimport foo3 from 'common/foo';\n\nimport bar4 from 'app/bar/bar';\nimport foo4 from 'app/bar/foo';\nimport bar5 from 'app/foo/bar';\nimport foo5 from 'app/foo/foo';\n",
             parserOptions: parserOptions
+        },
+        {
+            // When the path is the same, keep user's order
+            code: "import {bar1} from 'bar';\nimport {bar2} from 'bar';\nimport baz from 'baz';\nimport {foo2} from 'foo';\nimport {foo1} from 'foo';",
+            parserOptions: parserOptions
         }
 
     ],


### PR DESCRIPTION
## What does this PR solve

When we have 
```js
import { foo } from './a';
import { bar } from './a';
```

sometimes, they get flipped.

This use case is specially noticeable in typescript:

```ts
import { foo } from './a';
import type { foo } from './a';
```

## How does this PR work

This PR adds stable sorting by using `0` in addition to `-1` and `1` in the .sort() method.

=> If 2 imports have the same path, we keep them as they are instead of forcing the 2nd one to be at the end and the 1st one at the beginning

## Follow-up

We should enforce an order between `import` and `import type`

Maybe "if the paths are the same, put import type after" or "put all import types after".
Even if I had a preference (the 1st one), it's not my lib, so your call :D 

I don't want to do that now because:
- it's a broader question
- it'll break the order for everyone
I just want to fix 1 bug