### PR TITLE
Add `preferRelative` and `replaceAbsolutePathStart` options to `import-absolute`

### DIFF
--- a/docs/rules/import-absolutes.md
+++ b/docs/rules/import-absolutes.md
@@ -30,7 +30,7 @@ import foo from './foo';
 import hello from './hello';
 ```
 
-If an import comes from the current package, and its relative form matches `preferRelative`, this rule will produce a warning.
+If an absolute import comes from the current package and the relative path to its target matches `preferRelative`, this rule will produce a warning.
 
 Inside a package named `pkg`, and when `preferRelative` is set to `^\\.\\/[^\\/]*$`, the following patterns are considered errors:
 

--- a/docs/rules/import-absolutes.md
+++ b/docs/rules/import-absolutes.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-Yarn 2 supports self-reference, making it possible for your local package to reference itself by using its own name in its imports, like it would for any other dependency. This rule leverages that to always use absolute imports rather than relative. It also properly supports workspaces.
+Yarn 2 supports self-reference, making it possible for your local package to reference itself by using its own name in its imports, like it would for any other dependency. The default behaviour of this rule leverages that to always use absolute imports rather than relative. It also properly supports workspaces.
 
 The following patterns are considered warnings:
 
@@ -19,15 +19,43 @@ import foo from 'pkg/test';
 
 ## Options
 
-### `keepRelative`
+### `preferRelative`
 
-A regex pattern specifying which import paths should be allowed to remain relative.
+A regex pattern specifying which import paths should be kept or made relative.
 
-The following patterns are not considered warnings are not considered warning when `keepRelative` is set to `^\\.\\/[^\\/]*$`:
+The following patterns are not considered warning when `preferRelative` is set to `^\\.\\/[^\\/]*$`:
 
 ```js
 import foo from './foo';
 import hello from './hello';
+```
+
+If an import comes from the current package, and its relative form matches `preferRelative`, this rule will produce a warning.
+
+Inside a package named `pkg`, and when `preferRelative` is set to `^\\.\\/[^\\/]*$`, the following patterns are considered errors:
+
+```js
+// importing from a file located in 'pkg/bar'
+import foo from 'pkg/bar/foo';
+```
+
+### `replaceAbsolutePathStart`
+
+An array of objects specifying alternatives for absolute paths starts. When
+specified, and the rule finds that an absolute import should be used, each
+element of the array is used until a matching one is found (if any).
+
+Each element of the array must be an object with two properties:
+
+- `from` is what the absolute import should start with for it to match,
+- `to` is what to replace `from` with in the absolute import.
+
+The behaviour is undefined unless `from` and `to` are absolute import paths.
+
+The following patterns are considered warnings when `replaceAbsolutePathStart` is set to `[{ from: 'foo/bar', to: 'fff' }]`:
+
+```js
+import baz from 'foo/bar/baz';
 ```
 
 ## When Not To Use It

--- a/docs/rules/import-absolutes.md
+++ b/docs/rules/import-absolutes.md
@@ -16,6 +16,20 @@ The following patterns are not warnings:
 import foo from 'pkg/test';
 ```
 
+
+## Options
+
+### `keepRelative`
+
+A regex pattern specifying which import paths should be allowed to remain relative.
+
+The following patterns are not considered warnings are not considered warning when `keepRelative` is set to `^\\.\\/[^\\/]*$`:
+
+```js
+import foo from './foo';
+import hello from './hello';
+```
+
 ## When Not To Use It
 
 You may want to disable this rule if you don't work with Maël.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "prepack": "rm -rf lib && rollup -c",
     "postpack": "rm -rf lib",
-    "test": "yarn mocha --require $(node -p 'require.resolve(\"ts-node/register/transpile-only\")') --reporter dot **/*.test.ts",
+    "_test": "yarn mocha --require $(node -p 'require.resolve(\"ts-node/register/transpile-only\")') --reporter dot",
+    "test": "yarn _test **/*.test.ts",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"
   },

--- a/sources/rules/import-absolutes.ts
+++ b/sources/rules/import-absolutes.ts
@@ -20,20 +20,6 @@ const isRelative = (path: string): boolean => !isAbsolute(path);
 
 const withEndSep = (input: string) => input.endsWith(path.sep) ? input : `${input}${path.sep}`;
 
-const getBareSpecifier = (importPath: string) => {
-  const [head] = path.normalize(importPath).split(`/`);
-  return head;
-};
-const removeBareSpecifier = (importPath: string) => {
-  const [head, ...rest] = path.normalize(importPath).split(`/`);
-
-  if (rest.length === 0) {
-    return head;
-  } else {
-    return rest.join(`/`);
-  }
-};
-
 const getReplaceAbsolutePathStart = (
   replacementSpecs: Array<{from: string, to: string}>
 ): (path: string) => {adjustedPath: string, from: string, to: string} | null => {
@@ -105,7 +91,7 @@ const rule: Rule.RuleModule = {
 
     function isPackageImport(importPath: string): boolean {
       return isRelative(importPath) ||
-        getBareSpecifier(importPath) === packageInfo.name;
+        importPath.startsWith(packageInfo.name);
     }
 
     function getImportInfo(importPath: string): ImportInfo | null {
@@ -118,7 +104,7 @@ const rule: Rule.RuleModule = {
 
       const targetPath = isRelative(importPath) ?
         path.resolve(sourceDirName, importPath)
-        : path.join(packageDir, removeBareSpecifier(importPath));
+        : path.join(packageDir, importPath.slice(packageInfo.name.length));
 
       return {
         absolutePath: `${packageInfo.name}/${path.relative(packageDir, targetPath)}`,

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -19,6 +19,10 @@ ruleTester.run(`import-absolutes`, rule, {
     // When the path is the same, keep user's order
     code: `import {bar1} from 'bar';\nimport {bar2} from 'bar';\nimport baz from 'baz';\nimport {foo2} from 'foo';\nimport {foo1} from 'foo';`,
     parserOptions,
+  }, {
+    code: `import './foo';\n`,
+    parserOptions,
+    options: [{keepRelative: `^\\.\\/[^\\/]*$`}],
   }],
   invalid: [{
     code: `import './foo';\n`,
@@ -26,5 +30,11 @@ ruleTester.run(`import-absolutes`, rule, {
     filename: __filename,
     parserOptions,
     errors: [{message: `Expected import to be package-absolute (rather than './foo').`}],
-  }],
+  }, {
+    code: `import '../foo';\n`,
+    output: `import 'eslint-plugin-arca/tests/foo';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected import to be package-absolute (rather than '../foo').`}],
+    options: [{keepRelative: `^\\.\\/[^\\/]*$`}]}],
 });

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -36,5 +36,12 @@ ruleTester.run(`import-absolutes`, rule, {
     filename: __filename,
     parserOptions,
     errors: [{message: `Expected import to be package-absolute (rather than '../foo').`}],
+    options: [{keepRelative: `^\\.\\/[^\\/]*$`}],
+  }, {
+    code: `import './/foo';\n`,
+    output: `import './foo';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be normalized (rather than './/foo')`}],
     options: [{keepRelative: `^\\.\\/[^\\/]*$`}]}],
 });

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -22,26 +22,26 @@ ruleTester.run(`import-absolutes`, rule, {
   }, {
     code: `import './foo';\n`,
     parserOptions,
-    options: [{keepRelative: `^\\.\\/[^\\/]*$`}],
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
   }],
   invalid: [{
     code: `import './foo';\n`,
     output: `import 'eslint-plugin-arca/tests/rules/foo';\n`,
     filename: __filename,
     parserOptions,
-    errors: [{message: `Expected import to be package-absolute (rather than './foo').`}],
+    errors: [{message: `Expected relative import to be package-absolute (rather than './foo').`}],
   }, {
     code: `import '../foo';\n`,
     output: `import 'eslint-plugin-arca/tests/foo';\n`,
     filename: __filename,
     parserOptions,
-    errors: [{message: `Expected import to be package-absolute (rather than '../foo').`}],
-    options: [{keepRelative: `^\\.\\/[^\\/]*$`}],
+    errors: [{message: `Expected relative import to be package-absolute (rather than '../foo').`}],
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
   }, {
     code: `import './/foo';\n`,
     output: `import './foo';\n`,
     filename: __filename,
     parserOptions,
-    errors: [{message: `Expected relative import to be normalized (rather than './/foo')`}],
-    options: [{keepRelative: `^\\.\\/[^\\/]*$`}]}],
+    errors: [{message: `Expected relative import to be normalized (rather than './/foo').`}],
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}]}],
 });

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -22,7 +22,7 @@ ruleTester.run(`import-absolutes`, rule, {
   }],
   invalid: [{
     code: `import './foo';\n`,
-    output: `import 'eslint-plugin-arca/tests/lib/rules/foo';\n`,
+    output: `import 'eslint-plugin-arca/tests/rules/foo';\n`,
     filename: __filename,
     parserOptions,
     errors: [{message: `Expected import to be package-absolute (rather than './foo').`}],

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -23,8 +23,18 @@ ruleTester.run(`import-absolutes`, rule, {
     code: `import './foo';\n`,
     parserOptions,
     options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
+  }, {
+    code: `import './';\n`,
+    parserOptions,
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
   }],
   invalid: [{
+    code: `import './';\n`,
+    output: `import 'eslint-plugin-arca/tests/rules';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be package-absolute (rather than './').`}],
+  }, {
     code: `import './foo';\n`,
     output: `import 'eslint-plugin-arca/tests/rules/foo';\n`,
     filename: __filename,

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -43,5 +43,26 @@ ruleTester.run(`import-absolutes`, rule, {
     filename: __filename,
     parserOptions,
     errors: [{message: `Expected relative import to be normalized (rather than './/foo').`}],
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
+  }, {
+    code: `import '../foo';\n`,
+    output: `import 'fff/foo';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be package-absolute (rather than '../foo').`}],
+    options: [{replaceAbsolutePathStart: [{from: `eslint-plugin-arca/tests`, to: `fff`}]}]},
+  {
+    code: `import 'eslint-plugin-arca/tests/rules/bar';\n`,
+    output: `import 'fff/rules/bar';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected absolute import to start with 'fff/' prefix (rather than 'eslint-plugin-arca/tests/').`}],
+    options: [{replaceAbsolutePathStart: [{from: `eslint-plugin-arca/tests`, to: `fff`}]}],
+  }, {
+    code: `import 'eslint-plugin-arca/tests/rules/baz';\nimport 'eslint-plugin-arca/tests/rules/jeej/baz';\n`,
+    output: `import './baz';\nimport 'eslint-plugin-arca/tests/rules/jeej/baz';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected absolute import to be relative (rather than 'eslint-plugin-arca/tests/rules/baz').`}],
     options: [{preferRelative: `^\\.\\/[^\\/]*$`}]}],
 });


### PR DESCRIPTION
## `preferRelative`

`preferRelative` lets one specify which import path should be kept or made relative.

- if an import path is relative, and matches the option, it is kept relative.
- if an import path is from the current package, absolute and its relative form matches the option, it is changed to its relative form.

For instance, if set to `^\\.\\/[^\\/]*$`, the following patterns are not considered warnings:

```js
import foo from './foo';
import hello from './hello';
```

If set to `^\\.\\/[^\\/]*$`, when the current package is named `pkg`, and importing from `pkg/bar`, the following pattern is considered a warning:

```js
import foo from 'pkg/bar/foo`;
```

## `replaceAbsolutePathStart`

This lets one specify replacement prefixes when the rule finds that an absolute import must be used. An arbitrary number of prefixes may be specified; the first one matching is used, if any.

The following patterns are considered warnings when `replaceAbsolutePathStart` is set to `[{ from: 'foo/bar', to: 'fff' }]`:

```js
import baz from 'foo/bar/baz';
```