### PR TITLE
Fix import-absolutes for packages starting similarly to current package

### DIFF
--- a/sources/rules/import-absolutes.ts
+++ b/sources/rules/import-absolutes.ts
@@ -91,7 +91,7 @@ const rule: Rule.RuleModule = {
 
     function isPackageImport(importPath: string): boolean {
       return isRelative(importPath) ||
-        importPath.startsWith(packageInfo.name);
+        importPath.startsWith(`${packageInfo.name}/`);
     }
 
     function getImportInfo(importPath: string): ImportInfo | null {

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -30,6 +30,9 @@ ruleTester.run(`import-absolutes`, rule, {
   }, {
     code: `import 'eslint-plugin-arca-actually-another-package/foo';`,
     parserOptions,
+  }, {
+    code: `import 'eslint-plugin-arca';`,
+    parserOptions,
   }],
   invalid: [{
     code: `import './';\n`,

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -27,6 +27,9 @@ ruleTester.run(`import-absolutes`, rule, {
     code: `import './';\n`,
     parserOptions,
     options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
+  }, {
+    code: `import 'eslint-plugin-arca-actually-another-package/foo';`,
+    parserOptions,
   }],
   invalid: [{
     code: `import './';\n`,


### PR DESCRIPTION
The rule has logic to bail out when an import comes from another
package; to determine whether an import comes from another package, it
would check whether the import path starts with the current package name
or not.

This breaks when an import comes from another package whose name starts
with the current package's name. For instance:

Package.json:
```json
{
  "name": "foo"
}
```

Some ts file:
```ts
import 'foo-bar/baz';
```

This would be flagged as coming from the current package (named `foo`)
and the logic responsible for normalized path would compute
`foo/-bar/baz`.

The fix is to check wether an import path starts with the package name
plus a `/`.

This also fixes incorrectly transforming `import 'foo';` into
`import 'foo/';` (where `foo` is the current package's name).

Unit tests for both cases have been added.