### PR TITLE
Fix isAbsolute regex to flag `.` and `..` as relative

### DIFF
--- a/sources/rules/import-absolutes.ts
+++ b/sources/rules/import-absolutes.ts
@@ -15,7 +15,7 @@ type ImportInfo = {
   absolutePath: string;
 };
 
-const isAbsolute = (path: string): boolean => !path.match(/^\.{0,2}(\/.*)?$/);
+const isAbsolute = (path: string): boolean => !path.match(/^\.{0,2}(\/|$)/);
 const isRelative = (path: string): boolean => !isAbsolute(path);
 
 const withEndSep = (input: string) => input.endsWith(path.sep) ? input : `${input}${path.sep}`;
@@ -106,9 +106,16 @@ const rule: Rule.RuleModule = {
         path.resolve(sourceDirName, importPath)
         : path.join(packageDir, importPath.slice(packageInfo.name.length));
 
+      let relativePath = path.relative(sourceDirName, targetPath) || `.`;
+
+      if (isAbsolute(relativePath))
+        relativePath = `./${relativePath}`;
+      if (relativePath.match(/(^|\/)\.{0,2}$/))
+        relativePath = `${relativePath}/index`;
+
       return {
         absolutePath: `${packageInfo.name}/${path.relative(packageDir, targetPath)}`,
-        relativePath: `./${path.relative(sourceDirName, targetPath)}` || `.`,
+        relativePath,
       };
     }
 

--- a/sources/rules/import-absolutes.ts
+++ b/sources/rules/import-absolutes.ts
@@ -15,7 +15,7 @@ type ImportInfo = {
   absolutePath: string;
 };
 
-const isAbsolute = (path: string): boolean => !path.match(/^\.{0,2}\//);
+const isAbsolute = (path: string): boolean => !path.match(/^\.{0,2}(\/.*)?$/);
 const isRelative = (path: string): boolean => !isAbsolute(path);
 
 const withEndSep = (input: string) => input.endsWith(path.sep) ? input : `${input}${path.sep}`;

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -35,6 +35,18 @@ ruleTester.run(`import-absolutes`, rule, {
     parserOptions,
   }],
   invalid: [{
+    code: `import '.';\n`,
+    output: `import 'eslint-plugin-arca/tests/rules';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be package-absolute (rather than '.').`}],
+  }, {
+    code: `import '..';\n`,
+    output: `import 'eslint-plugin-arca/tests';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be package-absolute (rather than '..').`}],
+  }, {
     code: `import './';\n`,
     output: `import 'eslint-plugin-arca/tests/rules';\n`,
     filename: __filename,

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -24,10 +24,6 @@ ruleTester.run(`import-absolutes`, rule, {
     parserOptions,
     options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
   }, {
-    code: `import './';\n`,
-    parserOptions,
-    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
-  }, {
     code: `import 'eslint-plugin-arca-actually-another-package/foo';`,
     parserOptions,
   }, {
@@ -47,11 +43,32 @@ ruleTester.run(`import-absolutes`, rule, {
     parserOptions,
     errors: [{message: `Expected relative import to be package-absolute (rather than '..').`}],
   }, {
+    code: `import 'eslint-plugin-arca/tests/foo';\n`,
+    output: `import '../foo';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected absolute import to be relative (rather than 'eslint-plugin-arca/tests/foo').`}],
+    options: [{preferRelative: `foo`}],
+  }, {
     code: `import './';\n`,
     output: `import 'eslint-plugin-arca/tests/rules';\n`,
     filename: __filename,
     parserOptions,
     errors: [{message: `Expected relative import to be package-absolute (rather than './').`}],
+  }, {
+    code: `import './';\n`,
+    output: `import './index';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be normalized (rather than './').`}],
+    options: [{preferRelative: `^\\.\\/[^\\/]*$`}],
+  }, {
+    code: `import '..';\n`,
+    output: `import '../index';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected relative import to be normalized (rather than '..').`}],
+    options: [{preferRelative: `..`}],
   }, {
     code: `import './foo';\n`,
     output: `import 'eslint-plugin-arca/tests/rules/foo';\n`,


### PR DESCRIPTION
The previous regex needed a trailing `/` to flag a path as relative. Now
both `.` and `..` are considered relative.

Additionally, turn `.` and `./` imports into `./index`.

Also test cases for that.