### PR TITLE
Improves the import-absolutes rule when used with the PnP API

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "eslintplugin",
     "eslint-plugin"
   ],
+  "workspaces": [
+    "tests/workspace"
+  ],
   "author": "Maël Nison",
   "main": "sources/index.ts",
   "scripts": {

--- a/tests/rules/import-absolutes.test.ts
+++ b/tests/rules/import-absolutes.test.ts
@@ -56,6 +56,18 @@ ruleTester.run(`import-absolutes`, rule, {
     parserOptions,
     errors: [{message: `Expected relative import to be package-absolute (rather than './').`}],
   }, {
+    code: `import 'eslint-plugin-arca/tests/workspace/lib';\n`,
+    output: `import 'eslint-plugin-arca-test-workspace/lib';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected absolute import to start with 'eslint-plugin-arca-test-workspace/' prefix (rather than 'eslint-plugin-arca/tests/workspace/').`}]
+  }, {
+    code: `import 'eslint-plugin-arca/tests/workspace';\n`,
+    output: `import 'eslint-plugin-arca-test-workspace';\n`,
+    filename: __filename,
+    parserOptions,
+    errors: [{message: `Expected absolute import to be 'eslint-plugin-arca-test-workspace' (rather than 'eslint-plugin-arca/tests/workspace').`}]
+  }, {
     code: `import './';\n`,
     output: `import './index';\n`,
     filename: __filename,

--- a/tests/workspace/package.json
+++ b/tests/workspace/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "eslint-plugin-arca-test-workspace"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-arca-test-workspace@workspace:tests/workspace":
+  version: 0.0.0-use.local
+  resolution: "eslint-plugin-arca-test-workspace@workspace:tests/workspace"
+  languageName: unknown
+  linkType: soft
+
 "eslint-plugin-arca@link:./::locator=eslint-plugin-arca%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "eslint-plugin-arca@link:./::locator=eslint-plugin-arca%40workspace%3A."


### PR DESCRIPTION
When used within a monorepo, the rule doesn't work very well. It misses incorrect paths such as:

```ts
import 'monorepo/packages/my-package/index.js';
```

With this diff, the import will instead be automatically fixed into:

```ts
import 'my-package/index.js';
```
