### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "workspaces": [
     "tests/workspace"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/arcanis/eslint-plugin-arca.git"
+  },
   "author": "Maël Nison",
   "main": "sources/index.ts",
   "scripts": {


### PR DESCRIPTION
Without it, it's not obvious to get to this repo from https://www.npmjs.com/package/eslint-plugin-arca